### PR TITLE
ci: build frontend image from frontend-next in deploy job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -173,7 +173,7 @@ jobs:
 
       - name: Build and push frontend image
         run: |
-          docker build -t "${{ steps.vars.outputs.frontend_image }}" ./frontend
+          docker build -t "${{ steps.vars.outputs.frontend_image }}" ./frontend-next
           docker push "${{ steps.vars.outputs.frontend_image }}"
 
       - name: Publish deployment manifest


### PR DESCRIPTION
Deploy Main failed because the deploy_main job still built the deleted ./frontend directory. Point it at ./frontend-next (matching the build_images job).